### PR TITLE
Use `isMassSpectrumList` and `isMassPeaksList`

### DIFF
--- a/R/countPeaks.R
+++ b/R/countPeaks.R
@@ -1,6 +1,6 @@
 countPeaks <- function(x){
   
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))==FALSE) {
+  if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   

--- a/R/deletePeaks.R
+++ b/R/deletePeaks.R
@@ -1,6 +1,6 @@
 deletePeaks <- function(x,min=NULL){
   
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))==FALSE) {
+  if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   if (is.null(min)){

--- a/R/detectOutliers.R
+++ b/R/detectOutliers.R
@@ -1,6 +1,6 @@
 detectOutliers <- function(x, by = NULL, binary = FALSE, ...){
-  
-  if (any(inherits(x, "list") & inherits(x[[1]], "MassPeaks")) == FALSE) {
+
+  if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   if ((!is.null(by)) & (is.vector(by))) {

--- a/R/peakPatterns.R
+++ b/R/peakPatterns.R
@@ -43,8 +43,8 @@ peakPatterns <- function(x,abs.lab=NA,barplot=TRUE,
   if (!is.na(abs.lab)){
     if (!any(x==abs.lab,na.rm=TRUE)) stop(paste("Label",abs.lab,"was not found in the data set"))
   }
-  
-  if ((class(x)=="list") & (class(x[[1]])=="MassPeaks")) {
+
+  if (isMassPeaksList(x)) {
     x <- intensityMatrix(x)
   }
   

--- a/R/screenSpectra.R
+++ b/R/screenSpectra.R
@@ -7,7 +7,7 @@ screenSpectra <- function(x,meta=NULL,threshold=1.5,estimator=c("Q","MAD"),
   method <- match.arg(method)
   smax <- 100 # re-scaling constant
   
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassSpectrum"))==FALSE) {
+  if (!isMassSpectrumList(x)) {
     stop("x must be a list of MassSpectra class objects")
   }
   if ((!is.null(meta)) & (is.vector(meta))){

--- a/R/snrPeaks.R
+++ b/R/snrPeaks.R
@@ -1,6 +1,6 @@
 snrPeaks <- function(x){
 
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))==FALSE) {
+  if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   

--- a/R/summaryPeaks.R
+++ b/R/summaryPeaks.R
@@ -1,6 +1,6 @@
 summaryPeaks <- function(x, digits = 4){
   
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))==FALSE) {
+  if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   

--- a/R/summarySpectra.R
+++ b/R/summarySpectra.R
@@ -1,6 +1,6 @@
 summarySpectra <- function(x, digits = 4){
   
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassSpectrum"))==FALSE) {
+  if (!isMassSpectrumList(x)) {
     stop("x must be a list of MassSpectrum class objects")
   }
   

--- a/R/wavSmoothing.R
+++ b/R/wavSmoothing.R
@@ -1,6 +1,6 @@
 wavSmoothing <- function(x,thresh.scale=2.5, ...){
 
-  if (any(inherits(x,"list") & inherits(x[[1]],"MassSpectrum"))==FALSE) {
+  if (!isMassSpectrumList(x)) {
     stop("x must be a list of MassSpectrum class objects")
   }
   


### PR DESCRIPTION
Dear Javier,

`MALDIquant` offers two functions to help you testing for `list`s of `MassSpectrum` or `MassPeaks` objects: 

- `isMassSpectrumList`
- `isMassPeaks`

This pull request replaces the `any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))==FALSE` construct by `!isMassPeaksList(x)`. IMHO your solution doesn't test what you had in mind: `any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))` is `TRUE` if just one element in a `list` is a `MassPeaks` element, even if all the others are different types, e.g.:
```r
x <- list(createMassPeaks(1:2, 1:2), "FOO")
any(inherits(x,"list") & inherits(x[[1]],"MassPeaks"))
```

`isMassPeaksList` is just `TRUE` if *all* elements in a `list` are `MassPeaks` objects.

To avoid typing you could replace the complete `if` block by your own function, e.g. in `MALDIquant` I use an internal function for this kind of stuff:

https://github.com/sgibb/MALDIquant/blob/cce5c679c5fde1a92f32bcfe503380c8146539b6/R/isMassObjectList-functions.R#L26-L33

BTW: you should use `&&` instead of `&` here. While `&` is vectorized and combines the logical operations elementwise, `&&` fails already if the first statement is `FALSE`; see also `?Logic`
BTW2: `inherits(x[[1]],"MassPeaks"))==FALSE` is bad style, use `!inherits(x[[1]], "MassPeaks")`

Best wishes,

Sebastian