### PR TITLE
Simplify `countPeaks` and add unit tests

### DIFF
--- a/R/countPeaks.R
+++ b/R/countPeaks.R
@@ -1,8 +1,7 @@
-countPeaks <- function(x){
-  
+countPeaks <- function(x) {
+
   if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
-  
-  unlist(lapply(x,function(x) length(mass(x))))
+  lengths(x)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,2 @@
+library("testthat")
+test_check("MALDIrppa")

--- a/tests/testthat/test_countPeaks.R
+++ b/tests/testthat/test_countPeaks.R
@@ -1,0 +1,17 @@
+context("countPeaks")
+
+test_that("countPeaks throws an error for non-MassPeaks lists", {
+    expect_error(countPeaks(1:10), "must be a list of MassPeaks")
+    expect_error(countPeaks(list(1:3, 1:3), "must be a list of MassPeaks"))
+    expect_error(countPeaks(list(createMassPeaks(1:2, 1:2),
+                                 createMassSpectrum(1:2, 1:2))),
+                 "must be a list of MassPeaks")
+})
+
+test_that("countPeaks returns correct results", {
+    expect_equal(countPeaks(list(createMassPeaks(1:2, 1:2))), 2)
+    expect_equal(countPeaks(list(createMassPeaks(1:2, 1:2),
+                                 createMassPeaks(1:3, 1:3),
+                                 createMassPeaks(1:4, 1:4),
+                                 createMassPeaks(1:5, 1:5))), 2:5)
+})


### PR DESCRIPTION
Dear Javier,

instead of `unlist(lapply(x, function(x)length(mass(x)))))` you could simply use the base function `lengths`.

You use the package `testthat` in your `DESCRIPTION` file but doesn't create any unit test. For a scientific package it is in my opinion very important to have unit tests to ensure that all functions do what they are supposed to do. Please see an example for `countPeaks` in this PR. (I will open an issue asking for unit tests).

Best wishes,

Sebastian