### PR TITLE
Simplify `deletePeaks`

### DIFF
--- a/R/deletePeaks.R
+++ b/R/deletePeaks.R
@@ -1,21 +1,11 @@
-deletePeaks <- function(x,min=NULL){
-  
+deletePeaks <- function(x, min=NULL){
+
   if (!isMassPeaksList(x)) {
     stop("x must be a list of MassPeaks class objects")
   }
   if (is.null(min)){
-    stop("A minimum peak height value must be given") 
+    stop("A minimum peak height value must be given")
   }
-  
-  peaks2 <- list()
-  
-  for (i in 1:length(x)){
-    t_int <- intensity(x[[i]])
-    t_mas <- mass(x[[i]])
-    mini <- which(t_int < min)
-    t_int <- t_int[-mini]
-    t_mas <- t_mas[-mini]
-    peaks2[[i]] <- createMassPeaks(mass=t_mas,intensity=t_int)
-  }
-  peaks2
+
+  lapply(x, function(xx)xx[intensity(xx) >= min])
 }


### PR DESCRIPTION
Dear Javier,

`MALDIquant` implements the subset operator `[` for `MassSpectrum` and `MassPeaks` objects. So in `deletePeaks` you could just use `peaks[[1]][intensity(peaks[[1]]) >= min]` instead of subsetting `intensity` and `mass` and subsequently creating a new `MassPeaks` object (BTW: in your current approach you loose all metadata).

A general advice: If you use a `for` loop you should pre-allocate the results vector/list before to avoid memory re-allocation in every iteration (growing lists a very slow in R); see also https://csgillespie.github.io/efficientR/programming.html#memory-allocation.

Best wishes,

Sebastian